### PR TITLE
FIX: Error finding multiple elements

### DIFF
--- a/src/facilito/utils/collectors.py
+++ b/src/facilito/utils/collectors.py
@@ -42,7 +42,7 @@ def get_video_detail_sync(url: str, page: Page) -> Video:
         raise VideoError(error_message) from e
 
     video_id = page.locator("input[name='video_id']").first.get_attribute("value")
-    course_id = page.locator("input[name='course_id']").get_attribute("value")
+    course_id = page.locator("input[name='course_id']").first.get_attribute("value")
 
     if video_id is None or course_id is None:
         error_message = f"[VIDEO] id not found: {url}"


### PR DESCRIPTION
Se soluciona el Error al encontrar múltiples elementos con el id "course_id"
```shell
Error: Error: strict mode violation: locator("input[name='course_id']") resolved to 2
elements:
    1) <input value="346" type="hidden" id="course_id" name="c…/> aka locator("#course_id")
    2) <input value="346" type="hidden" name="course_id"/> aka locator("#score-modal
input[name=\"course_id\"]")
```
## Cambios
Se reemplaza
```python
course_id = page.locator("input[name='course_id']").get_attribute("value")
```
Por
```python
course_id = page.locator("input[name='course_id']").first.get_attribute("value")
```