### PR TITLE
windows-amd64-support

### DIFF
--- a/src/facilito/downloaders/video.py
+++ b/src/facilito/downloaders/video.py
@@ -44,6 +44,9 @@ async def _download_vsd():
         ("windows", "x86_64"): release_url.format(
             version=version, bin="x86_64-pc-windows-msvc.zip"
         ),
+        ("windows", "amd64"): release_url.format(
+            version=version, bin="x86_64-pc-windows-msvc.zip"
+        ),
         ("windows", "arm64"): release_url.format(
             version=version, bin="aarch64-pc-windows-msvc.zip"
         ),


### PR DESCRIPTION
Se añadió soporte para la plataforma Windows AMD64

- Actualizado `src\facilito\downloaders\video.py` para agregar soporte de descarga de [vsd](https://github.com/clitic/vsd) para la arquitectura Windows AMD64.
- Incluida la URL del binario de `vsd` correspondiente a esta plataforma.
- Probado manualmente y funcionando correctamente en Windows AMD64.

Con este cambio se evita el error `[ERROR] Unsupported platform: windows amd64`.
