### PR TITLE
chore: remove ffmpeg and playwright install steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,14 +3,14 @@ name: Test
 on:
   push:
     paths-ignore:
-      - '*.md'
+      - "*.md"
 
     branches:
       - develop
 
   pull_request:
     paths-ignore:
-      - '*.md'
+      - "*.md"
 
 jobs:
   test:
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'poetry'
+          cache: "poetry"
 
       - name: Install Dependencies
         run: poetry install --with=dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,11 +29,6 @@ jobs:
         shell: bash
         run: pipx install poetry
 
-      - name: Install FFmpeg
-        uses: AnimMouse/setup-ffmpeg@v1
-        with:
-          version: master
-
       - name: Setup | Install Python
         uses: actions/setup-python@v5
         with:
@@ -42,9 +37,6 @@ jobs:
 
       - name: Install Dependencies
         run: poetry install --with=dev
-
-      - name: Install Playwright Browsers
-        run: poetry run python -m playwright install --with-deps
 
       - name: Lint with Ruff
         run: poetry run ruff check --output-format=github .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ Add recommended `poetry` installation instructions, provide detailed installatio
 
 * feat: add support for Windows AMD64 architecture
 
-- Add the &#34;windows, amd64&#34; mapping to the binary URLs, pointing to the 
+- Add the &#34;windows, amd64&#34; mapping to the binary URLs, pointing to the
 x86_64-pc-windows-msvc.zip binary. This expands the supported Windows architectures.
 - This change resolves the error: [ERROR] Unsupported platform: windows amd64.
 


### PR DESCRIPTION
- Remove FFmpeg and Playwright browser installation as they are no longer required.
- Style, use quoted strings in test workflow file